### PR TITLE
Fix wrong file link in admin waitlist table

### DIFF
--- a/src/components/admin/WaitlistTable.tsx
+++ b/src/components/admin/WaitlistTable.tsx
@@ -167,8 +167,8 @@ export const WaitlistTable = ({ waitlistData }: WaitlistTableProps) => {
                             {entry.file_url && (
                               <div>
                                 <p className="font-medium text-muted-foreground">Attached File:</p>
-                                <a 
-                                  href={`${STORAGE_URL}/waitlist-uploads/${entry.file_url}`}
+                                <a
+                                  href={entry.file_url}
                                   target="_blank"
                                   rel="noreferrer"
                                   className="inline-flex items-center gap-1 text-blue-600 hover:underline"


### PR DESCRIPTION
## Summary
- fix file download link in `WaitlistTable`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68426645a8d88332af1340c25d8ac7b7